### PR TITLE
Score IDs might not be present in recent scores

### DIFF
--- a/src/OsuSharp/Entities/Score.cs
+++ b/src/OsuSharp/Entities/Score.cs
@@ -26,7 +26,7 @@ namespace OsuSharp
         ///     Score id.
         /// </summary>
         [JsonProperty("score_id")]
-        public long ScoreId { get; internal set; }
+        public long? ScoreId { get; internal set; }
 
         /// <summary>
         ///     Username of the player.

--- a/src/OsuSharp/ReplayFile.cs
+++ b/src/OsuSharp/ReplayFile.cs
@@ -285,7 +285,7 @@ namespace OsuSharp
                 Timestamp = score.Date.Value.Ticks,
                 OsuVersion = 0,
                 PlayerName = score.Username,
-                OnlineScoreId = score.ScoreId // whatever it's both a long
+                OnlineScoreId = score.ScoreId ?? 0 // whatever it's both a long
             };
 
             var decompressedData = SevenZipLZMAHelper.Decompress(replay.CompressedReplayData);


### PR DESCRIPTION
Per https://github.com/ppy/osu-api/wiki it does not look like recent scores have IDs with them.
```
[{
    "beatmap_id"   : "987654",
    "score"        : "1234567",
    "maxcombo"     : "421",
    "count50"      : "10",
    "count100"     : "50",
    "count300"     : "300",
    "countmiss"    : "1",
    "countkatu"    : "10",
    "countgeki"    : "50",
    "perfect"      : "0",          // 1 = maximum combo of map reached, 0 otherwise
    "enabled_mods" : "76",         // bitwise flag representation of mods used. see reference
    "user_id"      : "1",
    "date"         : "2013-06-22 9:11:16", // in UTC
    "rank"         : "SH"
}, { ... }, ...]```