### PR TITLE
Support setting custom base URL

### DIFF
--- a/src/OsuSharp/OsuClient.cs
+++ b/src/OsuSharp/OsuClient.cs
@@ -14,7 +14,7 @@ namespace OsuSharp
     public sealed class OsuClient
     {
         #region Endpoints
-        private const string Root = "https://osu.ppy.sh/api";
+        private string Root => OsuSharpConfiguration.BaseUrl;
         private const string Beatmaps = "/get_beatmaps";
         private const string Scores = "/get_scores";
         private const string User = "/get_user";

--- a/src/OsuSharp/OsuSharpConfiguration.cs
+++ b/src/OsuSharp/OsuSharpConfiguration.cs
@@ -18,5 +18,10 @@ namespace OsuSharp
         ///     Defines the default separator to use when using <see cref="ModeExtensions.ToModeString(Mode, OsuClient)"/>.
         /// </summary>
         public string ModeSeparator { get; set; }
+
+        /// <summary>
+        ///     Defines the base URL to send requests to, without ending slash. Default to <c>https://osu.ppy.sh/api</c>.
+        /// </summary>
+        public string BaseUrl { get; set; } = "https://osu.ppy.sh/api";
     }
 }


### PR DESCRIPTION
This opens up the library for usage with custom API implementations, for example, [Ripple's one](https://docs.ripple.moe/docs/api/peppy).