### PR TITLE
Add rankings endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Thanks to the following contributors:
 - [Quahu](https://github.com/Quahu)
 - [Kieran](https://github.com/k-boyle)
 - [Francesco149](https://github.com/Francesco149) for Oppai.
+- [TheOmyNomy](https://github.com/TheOmyNomy)
 
 Thanks to JetBrains for giving an open source license for their products!
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ News
  - /news/{news} (Get News Post)
 
 Ranking
- - /rankings/{mode}/{type} (Get Ranking)
  - /spotlights (Get Spotlights)
 
 Wiki
@@ -194,6 +193,9 @@ OAuth Tokens
 
 Misc
  - /seasonal-backgrounds (Get Current Seasonal Backgrounds ; No Auth)
+
+Ranking
+ - /rankings/{mode}/{type} (Get Ranking)
 ```
 
 ## Contact

--- a/src/OsuSharp.Domain/Enums/RankingFilter.cs
+++ b/src/OsuSharp.Domain/Enums/RankingFilter.cs
@@ -1,0 +1,7 @@
+namespace OsuSharp.Domain;
+
+public enum RankingFilter
+{
+	All,
+	Friends
+}

--- a/src/OsuSharp.Domain/Enums/RankingFilter.cs
+++ b/src/OsuSharp.Domain/Enums/RankingFilter.cs
@@ -2,6 +2,6 @@ namespace OsuSharp.Domain;
 
 public enum RankingFilter
 {
-	All,
-	Friends
+    All,
+    Friends
 }

--- a/src/OsuSharp.Domain/Enums/RankingType.cs
+++ b/src/OsuSharp.Domain/Enums/RankingType.cs
@@ -2,8 +2,8 @@ namespace OsuSharp.Domain;
 
 public enum RankingType
 {
-	Spotlight,
-	Country,
-	Performance,
-	Score
+    Spotlight,
+    Country,
+    Performance,
+    Score
 }

--- a/src/OsuSharp.Domain/Enums/RankingType.cs
+++ b/src/OsuSharp.Domain/Enums/RankingType.cs
@@ -1,0 +1,9 @@
+namespace OsuSharp.Domain;
+
+public enum RankingType
+{
+	Spotlight,
+	Country,
+	Performance,
+	Score
+}

--- a/src/OsuSharp.Domain/Enums/RankingVariant.cs
+++ b/src/OsuSharp.Domain/Enums/RankingVariant.cs
@@ -1,0 +1,7 @@
+namespace OsuSharp.Domain;
+
+public enum RankingVariant
+{
+	Key4,
+	Key7
+}

--- a/src/OsuSharp.Domain/Enums/RankingVariant.cs
+++ b/src/OsuSharp.Domain/Enums/RankingVariant.cs
@@ -2,6 +2,6 @@ namespace OsuSharp.Domain;
 
 public enum RankingVariant
 {
-	Key4,
-	Key7
+    Key4,
+    Key7
 }

--- a/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
+++ b/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
@@ -450,6 +450,22 @@ public interface IOsuClient : IDisposable
         CancellationToken token = default);
 
     /// <summary>
+    /// Gets spotlight rankings from the API.
+    /// </summary>
+    /// <param name="gameMode">The game mode to fetch rankings from.</param>
+    /// <param name="page">(Optional) The page to fetch rankings from. Defaults to the first page.</param>
+    /// <param name="filter">(Optional) Filter by results by all or by friends. Defaults to all.</param>
+    /// <param name="spotlightId">(Optional) The spotlight ID. Defaults to the latest spotlight.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>Returns an <see cref="IRankingSpotlight"/> instance.</returns>
+    Task<IRankingSpotlight> GetSpotlightRankingsAsync(
+        GameMode gameMode,
+        int? page = null,
+        RankingFilter? filter = null,
+        int? spotlightId = null,
+        CancellationToken token = default);
+
+    /// <summary>
     /// Gets an access token from authorization code grant.
     /// </summary>
     /// <param name="code">

--- a/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
+++ b/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
@@ -466,6 +466,20 @@ public interface IOsuClient : IDisposable
         CancellationToken token = default);
 
     /// <summary>
+    /// Gets country rankings from the API.
+    /// </summary>
+    /// <param name="gameMode">The game mode to fetch rankings from.</param>
+    /// <param name="page">(Optional) The page to fetch rankings from. Defaults to the first page.</param>
+    /// <param name="filter">(Optional) Filter by results by all or by friends. Defaults to all.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>Returns an <see cref="IRankingCountry"/> instance.</returns>
+    Task<IRankingCountry> GetCountryRankingsAsync(
+        GameMode gameMode,
+        int? page = null,
+        RankingFilter? filter = null,
+        CancellationToken token = default);
+
+    /// <summary>
     /// Gets an access token from authorization code grant.
     /// </summary>
     /// <param name="code">

--- a/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
+++ b/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
@@ -498,6 +498,20 @@ public interface IOsuClient : IDisposable
         CancellationToken token = default);
 
     /// <summary>
+    /// Gets score rankings from the API.
+    /// </summary>
+    /// <param name="gameMode">The game mode to fetch rankings from.</param>
+    /// <param name="page">(Optional) The page to fetch rankings from. Defaults to the first page.</param>
+    /// <param name="filter">(Optional) Filter by results by all or by friends. Defaults to all.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>Returns an <see cref="IRankingScore"/> instance.</returns>
+    Task<IRankingScore> GetScoreRankingsAsync(
+        GameMode gameMode,
+        int? page = null,
+        RankingFilter? filter = null,
+        CancellationToken token = default);
+
+    /// <summary>
     /// Gets an access token from authorization code grant.
     /// </summary>
     /// <param name="code">

--- a/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
+++ b/src/OsuSharp.Domain/Interfaces/IOsuClient.cs
@@ -480,6 +480,24 @@ public interface IOsuClient : IDisposable
         CancellationToken token = default);
 
     /// <summary>
+    /// Gets performance rankings from the API.
+    /// </summary>
+    /// <param name="gameMode">The game mode to fetch rankings from.</param>
+    /// <param name="page">(Optional) The page to fetch rankings from. Defaults to the first page.</param>
+    /// <param name="countryCode">(Optional) The country to fetch rankings from. Defaults to none.</param>
+    /// <param name="filter">(Optional) Filter by results by all or by friends. Defaults to all.</param>
+    /// <param name="variant">(Optional) Filter by a mode-specific variant. Defaults to none.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>Returns an <see cref="IRankingPerformance"/> instance.</returns>
+    Task<IRankingPerformance> GetPerformanceRankingsAsync(
+        GameMode gameMode,
+        string? countryCode = null,
+        int? page = null,
+        RankingFilter? filter = null,
+        RankingVariant? variant = null,
+        CancellationToken token = default);
+
+    /// <summary>
     /// Gets an access token from authorization code grant.
     /// </summary>
     /// <param name="code">

--- a/src/OsuSharp.Domain/Interfaces/IRankingCountry.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingCountry.cs
@@ -4,7 +4,7 @@ namespace OsuSharp.Interfaces;
 
 public interface IRankingCountry : IClientEntity
 {
-	IRankingCursor Cursor { get; }
-	IReadOnlyList<IRankingCountryRanking> Ranking { get; }
-	int Total { get; }
+    IRankingCursor Cursor { get; }
+    IReadOnlyList<IRankingCountryRanking> Ranking { get; }
+    int Total { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IRankingCountry.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingCountry.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace OsuSharp.Interfaces;
 
-public interface IRankingCountry
+public interface IRankingCountry : IClientEntity
 {
 	IRankingCursor Cursor { get; }
 	IReadOnlyList<IRankingCountryRanking> Ranking { get; }

--- a/src/OsuSharp.Domain/Interfaces/IRankingCountry.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingCountry.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace OsuSharp.Interfaces;
+
+public interface IRankingCountry
+{
+	IRankingCursor Cursor { get; }
+	IReadOnlyList<IRankingCountryRanking> Ranking { get; }
+	int Total { get; }
+}

--- a/src/OsuSharp.Domain/Interfaces/IRankingCountryRanking.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingCountryRanking.cs
@@ -1,0 +1,11 @@
+namespace OsuSharp.Interfaces;
+
+public interface IRankingCountryRanking
+{
+	long ActiveUsers { get; }
+	string Code { get; }
+	IUserCountry Country { get; }
+	long Performance { get; }
+	long PlayCount { get; }
+	long RankedScore { get; }
+}

--- a/src/OsuSharp.Domain/Interfaces/IRankingCountryRanking.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingCountryRanking.cs
@@ -2,10 +2,10 @@ namespace OsuSharp.Interfaces;
 
 public interface IRankingCountryRanking
 {
-	long ActiveUsers { get; }
-	string Code { get; }
-	IUserCountry Country { get; }
-	long Performance { get; }
-	long PlayCount { get; }
-	long RankedScore { get; }
+    long ActiveUsers { get; }
+    string Code { get; }
+    IUserCountry Country { get; }
+    long Performance { get; }
+    long PlayCount { get; }
+    long RankedScore { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IRankingCursor.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingCursor.cs
@@ -1,0 +1,6 @@
+namespace OsuSharp.Interfaces;
+
+public interface IRankingCursor
+{
+	int? Page { get; }
+}

--- a/src/OsuSharp.Domain/Interfaces/IRankingCursor.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingCursor.cs
@@ -2,5 +2,5 @@ namespace OsuSharp.Interfaces;
 
 public interface IRankingCursor
 {
-	int? Page { get; }
+    int? Page { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IRankingPerformance.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingPerformance.cs
@@ -2,11 +2,9 @@ using System.Collections.Generic;
 
 namespace OsuSharp.Interfaces;
 
-public interface IRankingSpotlight : IClientEntity
+public interface IRankingPerformance : IClientEntity
 {
-	IReadOnlyList<IBeatmapset> Beatmapsets { get; }
 	IRankingCursor Cursor { get; }
 	IReadOnlyList<IUserStatistics> Ranking { get; }
-	IRankingSpotlightInformation Spotlight { get; }
 	int Total { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IRankingPerformance.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingPerformance.cs
@@ -4,7 +4,7 @@ namespace OsuSharp.Interfaces;
 
 public interface IRankingPerformance : IClientEntity
 {
-	IRankingCursor Cursor { get; }
-	IReadOnlyList<IUserStatistics> Ranking { get; }
-	int Total { get; }
+    IRankingCursor Cursor { get; }
+    IReadOnlyList<IUserStatistics> Ranking { get; }
+    int Total { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IRankingScore.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingScore.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace OsuSharp.Interfaces;
+
+public interface IRankingScore : IClientEntity
+{
+	IRankingCursor Cursor { get; }
+	IReadOnlyList<IUserStatistics> Ranking { get; }
+	int Total { get; }
+}

--- a/src/OsuSharp.Domain/Interfaces/IRankingScore.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingScore.cs
@@ -4,7 +4,7 @@ namespace OsuSharp.Interfaces;
 
 public interface IRankingScore : IClientEntity
 {
-	IRankingCursor Cursor { get; }
-	IReadOnlyList<IUserStatistics> Ranking { get; }
-	int Total { get; }
+    IRankingCursor Cursor { get; }
+    IReadOnlyList<IUserStatistics> Ranking { get; }
+    int Total { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IRankingSpotlight.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingSpotlight.cs
@@ -4,9 +4,9 @@ namespace OsuSharp.Interfaces;
 
 public interface IRankingSpotlight : IClientEntity
 {
-	IReadOnlyList<IBeatmapset> Beatmapsets { get; }
-	IRankingCursor Cursor { get; }
-	IReadOnlyList<IUserStatistics> Ranking { get; }
-	IRankingSpotlightInformation Spotlight { get; }
-	int Total { get; }
+    IReadOnlyList<IBeatmapset> Beatmapsets { get; }
+    IRankingCursor Cursor { get; }
+    IReadOnlyList<IUserStatistics> Ranking { get; }
+    IRankingSpotlightInformation Spotlight { get; }
+    int Total { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IRankingSpotlight.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingSpotlight.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace OsuSharp.Interfaces;
+
+public interface IRankingSpotlight
+{
+	IReadOnlyList<IBeatmapset> Beatmapsets { get; }
+	IRankingCursor Cursor { get; }
+	IReadOnlyList<IUserStatistics> Ranking { get; }
+	IRankingSpotlightInformation Spotlight { get; }
+	int Total { get; }
+}

--- a/src/OsuSharp.Domain/Interfaces/IRankingSpotlightInformation.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingSpotlightInformation.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace OsuSharp.Interfaces;
+
+public interface IRankingSpotlightInformation
+{
+	DateTime EndTime { get; }
+	int Id { get; }
+	bool ModeSpecific { get; }
+	int? ParticipantCount { get; }
+	string Name { get; }
+	DateTime StartDate { get; }
+	string Type { get; }
+}

--- a/src/OsuSharp.Domain/Interfaces/IRankingSpotlightInformation.cs
+++ b/src/OsuSharp.Domain/Interfaces/IRankingSpotlightInformation.cs
@@ -4,11 +4,11 @@ namespace OsuSharp.Interfaces;
 
 public interface IRankingSpotlightInformation
 {
-	DateTime EndTime { get; }
-	int Id { get; }
-	bool ModeSpecific { get; }
-	int? ParticipantCount { get; }
-	string Name { get; }
-	DateTime StartDate { get; }
-	string Type { get; }
+    DateTime EndTime { get; }
+    int Id { get; }
+    bool ModeSpecific { get; }
+    int? ParticipantCount { get; }
+    string Name { get; }
+    DateTime StartDate { get; }
+    string Type { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IUserGradeCounts.cs
+++ b/src/OsuSharp.Domain/Interfaces/IUserGradeCounts.cs
@@ -3,8 +3,8 @@
 public interface IUserGradeCounts
 {
     long SS { get; }
-    long SSH { get; }
+    long? SSH { get; }
     long S { get; }
-    long SH { get; }
+    long? SH { get; }
     long A { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IUserStatistics.cs
+++ b/src/OsuSharp.Domain/Interfaces/IUserStatistics.cs
@@ -16,4 +16,5 @@ public interface IUserStatistics
     IUserGradeCounts UserGradeCounts { get; }
     long CountryRank { get; }
     long GlobalRank { get; }
+    IUserCompact User { get; }
 }

--- a/src/OsuSharp.Domain/Interfaces/IUserStatistics.cs
+++ b/src/OsuSharp.Domain/Interfaces/IUserStatistics.cs
@@ -3,11 +3,11 @@
 public interface IUserStatistics
 {
     IUserLevel UserLevel { get; }
-    double Pp { get; }
+    double? Pp { get; }
     long RankedScore { get; }
     double HitAccuracy { get; }
     long PlayCount { get; }
-    long PlayTime { get; }
+    long? PlayTime { get; }
     long TotalScore { get; }
     long TotalHits { get; }
     long MaximumCombo { get; }
@@ -15,6 +15,6 @@ public interface IUserStatistics
     bool IsRanked { get; }
     IUserGradeCounts UserGradeCounts { get; }
     long CountryRank { get; }
-    long GlobalRank { get; }
+    long? GlobalRank { get; }
     IUserCompact User { get; }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingCountry.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCountry.cs
@@ -5,10 +5,10 @@ namespace OsuSharp.Domain;
 
 public class RankingCountry : IRankingCountry
 {
-	public IRankingCursor Cursor { get; internal set; } = null!;
-	public IReadOnlyList<IRankingCountryRanking> Ranking { get; internal set; } = null!;
-	public int Total { get; internal set; }
-	public IOsuClient Client { get; internal set; } = null!;
+    public IRankingCursor Cursor { get; internal set; } = null!;
+    public IReadOnlyList<IRankingCountryRanking> Ranking { get; internal set; } = null!;
+    public int Total { get; internal set; }
+    public IOsuClient Client { get; internal set; } = null!;
 
-	internal RankingCountry() { }
+    internal RankingCountry() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingCountry.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCountry.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using OsuSharp.Interfaces;
+
+namespace OsuSharp.Domain.Ranking;
+
+public class RankingCountry : IRankingCountry
+{
+	public IRankingCursor Cursor { get; internal set; } = null!;
+	public IReadOnlyList<IRankingCountryRanking> Ranking { get; internal set; } = null!;
+	public int Total { get; internal set; }
+}

--- a/src/OsuSharp.Domain/Ranking/RankingCountry.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCountry.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
 using OsuSharp.Interfaces;
 
-namespace OsuSharp.Domain.Ranking;
+namespace OsuSharp.Domain;
 
 public class RankingCountry : IRankingCountry
 {
 	public IRankingCursor Cursor { get; internal set; } = null!;
 	public IReadOnlyList<IRankingCountryRanking> Ranking { get; internal set; } = null!;
 	public int Total { get; internal set; }
+	public IOsuClient Client { get; internal set; } = null!;
+
+	internal RankingCountry() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingCountryRanking.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCountryRanking.cs
@@ -4,12 +4,12 @@ namespace OsuSharp.Domain;
 
 public class RankingCountryRanking : IRankingCountryRanking
 {
-	public long ActiveUsers { get; internal set; }
-	public string Code { get; internal set; } = null!;
-	public IUserCountry Country { get; internal set; } = null!;
-	public long Performance { get; internal set; }
-	public long PlayCount { get; internal set; }
-	public long RankedScore { get; internal set; }
+    public long ActiveUsers { get; internal set; }
+    public string Code { get; internal set; } = null!;
+    public IUserCountry Country { get; internal set; } = null!;
+    public long Performance { get; internal set; }
+    public long PlayCount { get; internal set; }
+    public long RankedScore { get; internal set; }
 
-	internal RankingCountryRanking() { }
+    internal RankingCountryRanking() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingCountryRanking.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCountryRanking.cs
@@ -1,0 +1,13 @@
+using OsuSharp.Interfaces;
+
+namespace OsuSharp.Domain.Ranking;
+
+public class RankingCountryRanking : IRankingCountryRanking
+{
+	public long ActiveUsers { get; internal set; }
+	public string Code { get; internal set; } = null!;
+	public IUserCountry Country { get; internal set; } = null!;
+	public long Performance { get; internal set; }
+	public long PlayCount { get; internal set; }
+	public long RankedScore { get; internal set; }
+}

--- a/src/OsuSharp.Domain/Ranking/RankingCountryRanking.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCountryRanking.cs
@@ -1,6 +1,6 @@
 using OsuSharp.Interfaces;
 
-namespace OsuSharp.Domain.Ranking;
+namespace OsuSharp.Domain;
 
 public class RankingCountryRanking : IRankingCountryRanking
 {
@@ -10,4 +10,6 @@ public class RankingCountryRanking : IRankingCountryRanking
 	public long Performance { get; internal set; }
 	public long PlayCount { get; internal set; }
 	public long RankedScore { get; internal set; }
+
+	internal RankingCountryRanking() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingCursor.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCursor.cs
@@ -1,8 +1,10 @@
 using OsuSharp.Interfaces;
 
-namespace OsuSharp.Domain.Ranking;
+namespace OsuSharp.Domain;
 
 public class RankingCursor : IRankingCursor
 {
 	public int? Page { get; internal set; } = null!;
+
+	internal RankingCursor() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingCursor.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCursor.cs
@@ -4,7 +4,7 @@ namespace OsuSharp.Domain;
 
 public class RankingCursor : IRankingCursor
 {
-	public int? Page { get; internal set; } = null!;
+    public int? Page { get; internal set; } = null!;
 
-	internal RankingCursor() { }
+    internal RankingCursor() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingCursor.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingCursor.cs
@@ -1,0 +1,8 @@
+using OsuSharp.Interfaces;
+
+namespace OsuSharp.Domain.Ranking;
+
+public class RankingCursor : IRankingCursor
+{
+	public int? Page { get; internal set; } = null!;
+}

--- a/src/OsuSharp.Domain/Ranking/RankingPerformance.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingPerformance.cs
@@ -3,14 +3,12 @@ using OsuSharp.Interfaces;
 
 namespace OsuSharp.Domain;
 
-public class RankingSpotlight : IRankingSpotlight
+public class RankingPerformance : IRankingPerformance
 {
-	public IReadOnlyList<IBeatmapset> Beatmapsets { get; internal set; } = null!;
 	public IRankingCursor Cursor { get; internal set; } = null!;
 	public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
-	public IRankingSpotlightInformation Spotlight { get; internal set; } = null!;
 	public int Total { get; internal set; }
 	public IOsuClient Client { get; internal set; } = null!;
 
-	internal RankingSpotlight() { }
+	internal RankingPerformance() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingPerformance.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingPerformance.cs
@@ -5,10 +5,10 @@ namespace OsuSharp.Domain;
 
 public class RankingPerformance : IRankingPerformance
 {
-	public IRankingCursor Cursor { get; internal set; } = null!;
-	public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
-	public int Total { get; internal set; }
-	public IOsuClient Client { get; internal set; } = null!;
+    public IRankingCursor Cursor { get; internal set; } = null!;
+    public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
+    public int Total { get; internal set; }
+    public IOsuClient Client { get; internal set; } = null!;
 
-	internal RankingPerformance() { }
+    internal RankingPerformance() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingScore.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingScore.cs
@@ -5,10 +5,10 @@ namespace OsuSharp.Domain;
 
 public class RankingScore : IRankingScore
 {
-	public IRankingCursor Cursor { get; internal set; } = null!;
-	public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
-	public int Total { get; internal set; }
-	public IOsuClient Client { get; internal set; } = null!;
+    public IRankingCursor Cursor { get; internal set; } = null!;
+    public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
+    public int Total { get; internal set; }
+    public IOsuClient Client { get; internal set; } = null!;
 
-	internal RankingScore() { }
+    internal RankingScore() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingScore.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingScore.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using OsuSharp.Interfaces;
+
+namespace OsuSharp.Domain;
+
+public class RankingScore : IRankingScore
+{
+	public IRankingCursor Cursor { get; internal set; } = null!;
+	public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
+	public int Total { get; internal set; }
+	public IOsuClient Client { get; internal set; } = null!;
+
+	internal RankingScore() { }
+}

--- a/src/OsuSharp.Domain/Ranking/RankingSpotlight.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingSpotlight.cs
@@ -5,12 +5,12 @@ namespace OsuSharp.Domain;
 
 public class RankingSpotlight : IRankingSpotlight
 {
-	public IReadOnlyList<IBeatmapset> Beatmapsets { get; internal set; } = null!;
-	public IRankingCursor Cursor { get; internal set; } = null!;
-	public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
-	public IRankingSpotlightInformation Spotlight { get; internal set; } = null!;
-	public int Total { get; internal set; }
-	public IOsuClient Client { get; internal set; } = null!;
+    public IReadOnlyList<IBeatmapset> Beatmapsets { get; internal set; } = null!;
+    public IRankingCursor Cursor { get; internal set; } = null!;
+    public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
+    public IRankingSpotlightInformation Spotlight { get; internal set; } = null!;
+    public int Total { get; internal set; }
+    public IOsuClient Client { get; internal set; } = null!;
 
-	internal RankingSpotlight() { }
+    internal RankingSpotlight() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingSpotlight.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingSpotlight.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using OsuSharp.Interfaces;
+
+namespace OsuSharp.Domain.Ranking;
+
+public class RankingSpotlight : IRankingSpotlight
+{
+	public IReadOnlyList<IBeatmapset> Beatmapsets { get; internal set; } = null!;
+	public IRankingCursor Cursor { get; internal set; } = null!;
+	public IReadOnlyList<IUserStatistics> Ranking { get; internal set; } = null!;
+	public IRankingSpotlightInformation Spotlight { get; internal set; } = null!;
+	public int Total { get; internal set; }
+}

--- a/src/OsuSharp.Domain/Ranking/RankingSpotlightInformation.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingSpotlightInformation.cs
@@ -1,7 +1,7 @@
 using System;
 using OsuSharp.Interfaces;
 
-namespace OsuSharp.Domain.Ranking;
+namespace OsuSharp.Domain;
 
 public class RankingSpotlightInformation : IRankingSpotlightInformation
 {
@@ -12,4 +12,6 @@ public class RankingSpotlightInformation : IRankingSpotlightInformation
 	public string Name { get; internal set; } = null!;
 	public DateTime StartDate { get; set; }
 	public string Type { get; internal set; } = null!;
+
+	internal RankingSpotlightInformation() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingSpotlightInformation.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingSpotlightInformation.cs
@@ -5,13 +5,13 @@ namespace OsuSharp.Domain;
 
 public class RankingSpotlightInformation : IRankingSpotlightInformation
 {
-	public DateTime EndTime { get; set; }
-	public int Id { get; set; }
-	public bool ModeSpecific { get; set; }
-	public int? ParticipantCount { get; internal set; } = null!;
-	public string Name { get; internal set; } = null!;
-	public DateTime StartDate { get; set; }
-	public string Type { get; internal set; } = null!;
+    public DateTime EndTime { get; set; }
+    public int Id { get; set; }
+    public bool ModeSpecific { get; set; }
+    public int? ParticipantCount { get; internal set; } = null!;
+    public string Name { get; internal set; } = null!;
+    public DateTime StartDate { get; set; }
+    public string Type { get; internal set; } = null!;
 
-	internal RankingSpotlightInformation() { }
+    internal RankingSpotlightInformation() { }
 }

--- a/src/OsuSharp.Domain/Ranking/RankingSpotlightInformation.cs
+++ b/src/OsuSharp.Domain/Ranking/RankingSpotlightInformation.cs
@@ -1,0 +1,15 @@
+using System;
+using OsuSharp.Interfaces;
+
+namespace OsuSharp.Domain.Ranking;
+
+public class RankingSpotlightInformation : IRankingSpotlightInformation
+{
+	public DateTime EndTime { get; set; }
+	public int Id { get; set; }
+	public bool ModeSpecific { get; set; }
+	public int? ParticipantCount { get; internal set; } = null!;
+	public string Name { get; internal set; } = null!;
+	public DateTime StartDate { get; set; }
+	public string Type { get; internal set; } = null!;
+}

--- a/src/OsuSharp.Domain/User/UserGradeCounts.cs
+++ b/src/OsuSharp.Domain/User/UserGradeCounts.cs
@@ -6,11 +6,11 @@ public sealed class UserGradeCounts : IUserGradeCounts
 {
     public long SS { get; internal set; }
 
-    public long SSH { get; internal set; }
+    public long? SSH { get; internal set; }
 
     public long S { get; internal set; }
 
-    public long SH { get; internal set; }
+    public long? SH { get; internal set; }
 
     public long A { get; internal set; }
 

--- a/src/OsuSharp.Domain/User/UserStatistics.cs
+++ b/src/OsuSharp.Domain/User/UserStatistics.cs
@@ -32,6 +32,8 @@ public sealed class UserStatistics : IUserStatistics
 
     public long GlobalRank { get; internal set; }
 
+    public IUserCompact User { get; internal set; } = null!;
+
     internal UserStatistics()
     {
             

--- a/src/OsuSharp.Domain/User/UserStatistics.cs
+++ b/src/OsuSharp.Domain/User/UserStatistics.cs
@@ -6,7 +6,7 @@ public sealed class UserStatistics : IUserStatistics
 {
     public IUserLevel UserLevel { get; internal set; } = null!;
 
-    public double Pp { get; internal set; }
+    public double? Pp { get; internal set; }
 
     public long RankedScore { get; internal set; }
 
@@ -14,7 +14,7 @@ public sealed class UserStatistics : IUserStatistics
 
     public long PlayCount { get; internal set; }
 
-    public long PlayTime { get; internal set; }
+    public long? PlayTime { get; internal set; }
 
     public long TotalScore { get; internal set; }
 
@@ -30,7 +30,7 @@ public sealed class UserStatistics : IUserStatistics
 
     public long CountryRank { get; internal set; }
 
-    public long GlobalRank { get; internal set; }
+    public long? GlobalRank { get; internal set; }
 
     public IUserCompact User { get; internal set; } = null!;
 

--- a/src/OsuSharp.JsonModels/Ranking/RankingCountryJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingCountryJsonModel.cs
@@ -9,7 +9,7 @@ public class RankingCountryJsonModel : JsonModel
 	public RankingCursorJsonModel Cursor { get; set; } = null!;
 
 	[JsonProperty("ranking")]
-	public IReadOnlyList<RankingCountryRankingJsonModel> Ranking { get; set; } = null!;
+	public List<RankingCountryRankingJsonModel> Ranking { get; set; } = null!;
 
 	[JsonProperty("total")]
 	public int Total { get; set; }

--- a/src/OsuSharp.JsonModels/Ranking/RankingCountryJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingCountryJsonModel.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace OsuSharp.JsonModels;
+
+public class RankingCountryJsonModel : JsonModel
+{
+	[JsonProperty("cursor")]
+	public RankingCursorJsonModel Cursor { get; set; } = null!;
+
+	[JsonProperty("ranking")]
+	public IReadOnlyList<RankingCountryRankingJsonModel> Ranking { get; set; } = null!;
+
+	[JsonProperty("total")]
+	public int Total { get; set; }
+}

--- a/src/OsuSharp.JsonModels/Ranking/RankingCountryJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingCountryJsonModel.cs
@@ -5,12 +5,12 @@ namespace OsuSharp.JsonModels;
 
 public class RankingCountryJsonModel : JsonModel
 {
-	[JsonProperty("cursor")]
-	public RankingCursorJsonModel Cursor { get; set; } = null!;
+      [JsonProperty("cursor")]
+      public RankingCursorJsonModel Cursor { get; set; } = null!;
 
-	[JsonProperty("ranking")]
-	public List<RankingCountryRankingJsonModel> Ranking { get; set; } = null!;
+      [JsonProperty("ranking")]
+      public List<RankingCountryRankingJsonModel> Ranking { get; set; } = null!;
 
-	[JsonProperty("total")]
-	public int Total { get; set; }
+      [JsonProperty("total")]
+      public int Total { get; set; }
 }

--- a/src/OsuSharp.JsonModels/Ranking/RankingCountryRankingJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingCountryRankingJsonModel.cs
@@ -4,21 +4,21 @@ namespace OsuSharp.JsonModels;
 
 public class RankingCountryRankingJsonModel : JsonModel
 {
-	[JsonProperty("active_users")]
-	public long ActiveUsers { get; set; }
+      [JsonProperty("active_users")]
+      public long ActiveUsers { get; set; }
 
-	[JsonProperty("code")]
-	public string Code { get; set; } = null!;
+      [JsonProperty("code")]
+      public string Code { get; set; } = null!;
 
-	[JsonProperty("country")]
-	public UserCountryJsonModel Country { get; set; } = null!;
+      [JsonProperty("country")]
+      public UserCountryJsonModel Country { get; set; } = null!;
 
-	[JsonProperty("performance")]
-	public long Performance { get; set; }
+      [JsonProperty("performance")]
+      public long Performance { get; set; }
 
-	[JsonProperty("play_count")]
-	public long PlayCount { get; set; }
+      [JsonProperty("play_count")]
+      public long PlayCount { get; set; }
 
-	[JsonProperty("ranked_score")]
-	public long RankedScore { get; set; }
+      [JsonProperty("ranked_score")]
+      public long RankedScore { get; set; }
 }

--- a/src/OsuSharp.JsonModels/Ranking/RankingCountryRankingJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingCountryRankingJsonModel.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace OsuSharp.JsonModels;
+
+public class RankingCountryRankingJsonModel : JsonModel
+{
+	[JsonProperty("active_users")]
+	public long ActiveUsers { get; set; }
+
+	[JsonProperty("code")]
+	public string Code { get; set; } = null!;
+
+	[JsonProperty("country")]
+	public UserCountryJsonModel Country { get; set; } = null!;
+
+	[JsonProperty("performance")]
+	public long Performance { get; set; }
+
+	[JsonProperty("play_count")]
+	public long PlayCount { get; set; }
+
+	[JsonProperty("ranked_score")]
+	public long RankedScore { get; set; }
+}

--- a/src/OsuSharp.JsonModels/Ranking/RankingCursorJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingCursorJsonModel.cs
@@ -4,6 +4,6 @@ namespace OsuSharp.JsonModels;
 
 public class RankingCursorJsonModel : JsonModel
 {
-	[JsonProperty("page")]
-	public int? Page { get; set; }
+      [JsonProperty("page")]
+      public int? Page { get; set; }
 }

--- a/src/OsuSharp.JsonModels/Ranking/RankingCursorJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingCursorJsonModel.cs
@@ -1,0 +1,9 @@
+using Newtonsoft.Json;
+
+namespace OsuSharp.JsonModels;
+
+public class RankingCursorJsonModel : JsonModel
+{
+	[JsonProperty("page")]
+	public int? Page { get; set; }
+}

--- a/src/OsuSharp.JsonModels/Ranking/RankingPerformanceJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingPerformanceJsonModel.cs
@@ -5,12 +5,12 @@ namespace OsuSharp.JsonModels;
 
 public class RankingPerformanceJsonModel : JsonModel
 {
-	[JsonProperty("cursor")]
-	public RankingCursorJsonModel Cursor { get; set; } = null!;
+      [JsonProperty("cursor")]
+      public RankingCursorJsonModel Cursor { get; set; } = null!;
 
-	[JsonProperty("ranking")]
-	public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
+      [JsonProperty("ranking")]
+      public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
 
-	[JsonProperty("total")]
-	public int Total { get; set; }
+      [JsonProperty("total")]
+      public int Total { get; set; }
 }

--- a/src/OsuSharp.JsonModels/Ranking/RankingPerformanceJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingPerformanceJsonModel.cs
@@ -3,19 +3,13 @@ using Newtonsoft.Json;
 
 namespace OsuSharp.JsonModels;
 
-public class RankingSpotlightJsonModel : JsonModel
+public class RankingPerformanceJsonModel : JsonModel
 {
-	[JsonProperty("beatmapsets")]
-	public List<BeatmapsetJsonModel> Beatmapsets { get; set; } = null!;
-
 	[JsonProperty("cursor")]
 	public RankingCursorJsonModel Cursor { get; set; } = null!;
 
 	[JsonProperty("ranking")]
 	public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
-
-	[JsonProperty("spotlight")]
-	public RankingSpotlightInformationJsonModel Spotlight { get; set; } = null!;
 
 	[JsonProperty("total")]
 	public int Total { get; set; }

--- a/src/OsuSharp.JsonModels/Ranking/RankingScoreJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingScoreJsonModel.cs
@@ -5,12 +5,12 @@ namespace OsuSharp.JsonModels;
 
 public class RankingScoreJsonModel : JsonModel
 {
-	[JsonProperty("cursor")]
-	public RankingCursorJsonModel Cursor { get; set; } = null!;
+      [JsonProperty("cursor")]
+      public RankingCursorJsonModel Cursor { get; set; } = null!;
 
-	[JsonProperty("ranking")]
-	public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
+      [JsonProperty("ranking")]
+      public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
 
-	[JsonProperty("total")]
-	public int Total { get; set; }
+      [JsonProperty("total")]
+      public int Total { get; set; }
 }

--- a/src/OsuSharp.JsonModels/Ranking/RankingScoreJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingScoreJsonModel.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace OsuSharp.JsonModels;
+
+public class RankingScoreJsonModel : JsonModel
+{
+	[JsonProperty("cursor")]
+	public RankingCursorJsonModel Cursor { get; set; } = null!;
+
+	[JsonProperty("ranking")]
+	public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
+
+	[JsonProperty("total")]
+	public int Total { get; set; }
+}

--- a/src/OsuSharp.JsonModels/Ranking/RankingSpotlightInformationJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingSpotlightInformationJsonModel.cs
@@ -5,8 +5,8 @@ namespace OsuSharp.JsonModels;
 
 public class RankingSpotlightInformationJsonModel : JsonModel
 {
-	[JsonProperty("end_date")]
-	public DateTime EndTime { get; set; }
+      [JsonProperty("end_date")]
+      public DateTime EndTime { get; set; }
 
 	[JsonProperty("id")]
 	public int Id { get; set; }

--- a/src/OsuSharp.JsonModels/Ranking/RankingSpotlightInformationJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingSpotlightInformationJsonModel.cs
@@ -1,0 +1,28 @@
+using System;
+using Newtonsoft.Json;
+
+namespace OsuSharp.JsonModels;
+
+public class RankingSpotlightInformationJsonModel : JsonModel
+{
+	[JsonProperty("end_date")]
+	public DateTime EndTime { get; set; }
+
+	[JsonProperty("id")]
+	public int Id { get; set; }
+
+	[JsonProperty("mode_specific")]
+	public bool ModeSpecific { get; set; }
+
+	[JsonProperty("participant_count")]
+	public int? ParticipantCount { get; set; }
+
+	[JsonProperty("name")]
+	public string Name { get; set; } = null!;
+
+	[JsonProperty("start_date")]
+	public DateTime StartDate { get; set; }
+
+	[JsonProperty("type")]
+	public string Type { get; set; } = null!;
+}

--- a/src/OsuSharp.JsonModels/Ranking/RankingSpotlightJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingSpotlightJsonModel.cs
@@ -5,18 +5,18 @@ namespace OsuSharp.JsonModels;
 
 public class RankingSpotlightJsonModel : JsonModel
 {
-	[JsonProperty("beatmapsets")]
-	public List<BeatmapsetJsonModel> Beatmapsets { get; set; } = null!;
+      [JsonProperty("beatmapsets")]
+      public List<BeatmapsetJsonModel> Beatmapsets { get; set; } = null!;
 
-	[JsonProperty("cursor")]
-	public RankingCursorJsonModel Cursor { get; set; } = null!;
+      [JsonProperty("cursor")]
+      public RankingCursorJsonModel Cursor { get; set; } = null!;
 
-	[JsonProperty("ranking")]
-	public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
+      [JsonProperty("ranking")]
+      public List<UserStatisticsJsonModel> Ranking { get; set; } = null!;
 
-	[JsonProperty("spotlight")]
-	public RankingSpotlightInformationJsonModel Spotlight { get; set; } = null!;
+      [JsonProperty("spotlight")]
+      public RankingSpotlightInformationJsonModel Spotlight { get; set; } = null!;
 
-	[JsonProperty("total")]
-	public int Total { get; set; }
+      [JsonProperty("total")]
+      public int Total { get; set; }
 }

--- a/src/OsuSharp.JsonModels/Ranking/RankingSpotlightJsonModel.cs
+++ b/src/OsuSharp.JsonModels/Ranking/RankingSpotlightJsonModel.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace OsuSharp.JsonModels;
+
+public class RankingSpotlightJsonModel : JsonModel
+{
+	[JsonProperty("beatmapsets")]
+	public List<BeatmapsetJsonModel> Beatmapsets { get; set; } = null!;
+
+	[JsonProperty("cursor")]
+	public RankingCursorJsonModel Cursor { get; set; } = null!;
+
+	[JsonProperty("ranking")]
+	public UserStatisticsJsonModel Ranking { get; set; } = null!;
+
+	[JsonProperty("spotlight")]
+	public RankingSpotlightInformationJsonModel Spotlight { get; set; } = null!;
+
+	[JsonProperty("total")]
+	public int Total { get; set; }
+}

--- a/src/OsuSharp.JsonModels/User/UserGradeCountsJsonModel.cs
+++ b/src/OsuSharp.JsonModels/User/UserGradeCountsJsonModel.cs
@@ -8,13 +8,13 @@ public class UserGradeCountsJsonModel : JsonModel
     public long SS { get; set; }
 
     [JsonProperty("ssh")]
-    public long SSH { get; set; }
+    public long? SSH { get; set; }
 
     [JsonProperty("s")]
     public long S { get; set; }
 
     [JsonProperty("sh")]
-    public long SH { get; set; }
+    public long? SH { get; set; }
 
     [JsonProperty("a")]
     public long A { get; set; }

--- a/src/OsuSharp.JsonModels/User/UserStatisticsJsonModel.cs
+++ b/src/OsuSharp.JsonModels/User/UserStatisticsJsonModel.cs
@@ -45,4 +45,7 @@ public class UserStatisticsJsonModel : JsonModel
 
     [JsonProperty("global_rank")]
     public long GlobalRank { get; set; }
+
+    [JsonProperty("user")]
+    public UserJsonModel User { get; set; } = null!;
 }

--- a/src/OsuSharp.JsonModels/User/UserStatisticsJsonModel.cs
+++ b/src/OsuSharp.JsonModels/User/UserStatisticsJsonModel.cs
@@ -8,7 +8,7 @@ public class UserStatisticsJsonModel : JsonModel
     public UserLevelJsonModel UserLevel { get; set; } = null!;
 
     [JsonProperty("pp")]
-    public double Pp { get; set; }
+    public double? Pp { get; set; }
 
     [JsonProperty("ranked_score")]
     public long RankedScore { get; set; }
@@ -20,7 +20,7 @@ public class UserStatisticsJsonModel : JsonModel
     public long PlayCount { get; set; }
 
     [JsonProperty("play_time")]
-    public long PlayTime { get; set; }
+    public long? PlayTime { get; set; }
 
     [JsonProperty("total_score")]
     public long TotalScore { get; set; }
@@ -44,7 +44,7 @@ public class UserStatisticsJsonModel : JsonModel
     public long CountryRank { get; set; }
 
     [JsonProperty("global_rank")]
-    public long GlobalRank { get; set; }
+    public long? GlobalRank { get; set; }
 
     [JsonProperty("user")]
     public UserJsonModel User { get; set; } = null!;

--- a/src/OsuSharp/Endpoints.cs
+++ b/src/OsuSharp/Endpoints.cs
@@ -18,6 +18,7 @@ internal static class Endpoints
     public const string Search = "/search";
     public const string Download = "/download";
     public const string SeasonalBackgrounds = "/seasonal-backgrounds";
+    public const string Rankings = "/rankings";
 
     public const string CurrentEndpoint = Api + Me;
     public const string UserEndpoint = Api + Users;
@@ -39,4 +40,5 @@ internal static class Endpoints
     public const string ScoresDownloadEndpoint = Api + Scores + "/{0}" + "/{1}" + Download;
     public const string CurrentTokensEndpoint = Oauth + Tokens + Current;
     public const string TokenEndpoint = Oauth + Token;
+    public const string RankingsEndpoint = Api + Rankings + "/{0}" + "/{1}";
 }

--- a/src/OsuSharp/Extensions/EnumExtensions.cs
+++ b/src/OsuSharp/Extensions/EnumExtensions.cs
@@ -105,4 +105,56 @@ internal static class EnumExtensions
     {
         return mods.HasValue ? ToApiString(mods.Value) : "";
     }
+
+    /// <summary>
+    /// Returns a string that fits osu! API requirements for <see cref="RankingFilter" />.
+    /// </summary>
+    /// <param name="rankingFilter">The filter to get the string for.</param>
+    /// <returns>A api-valid string representation of <see cref="RankingFilter" />.</returns>
+    public static string ToApiString(this RankingFilter rankingFilter)
+    {
+        return rankingFilter switch
+        {
+            RankingFilter.All => "all",
+            RankingFilter.Friends => "friends",
+            _ => ""
+        };
+    }
+
+    /// <summary>
+    /// Returns a string that fits osu! API requirements for <see cref="RankingFilter" />.
+    /// </summary>
+    /// <param name="rankingFilter">The filter to get the string for.</param>
+    /// <returns>A api-valid string representation of <see cref="RankingFilter" />.</returns>
+    public static string ToApiString(this RankingFilter? rankingFilter)
+    {
+        return rankingFilter.HasValue ? ToApiString(rankingFilter.Value) : "";
+    }
+
+    /// <summary>
+    /// Returns a string that fits osu! API requirements for <see cref="RankingType" />.
+    /// </summary>
+    /// <param name="rankingType">The type to get the string for.</param>
+    /// <returns>A api-valid string representation of <see cref="RankingType" />.</returns>
+    public static string ToApiString(this RankingType rankingType)
+    {
+        return rankingType switch
+        {
+            RankingType.Spotlight => "charts",
+            RankingType.Country => "country",
+            RankingType.Performance => "performance",
+            RankingType.Score => "score",
+            _ => ""
+        };
+    }
+
+    /// <summary>
+    /// Returns a string that fits osu! API requirements for <see cref="RankingType" />.
+    /// </summary>
+    /// <param name="rankingType">The type to get the string for.</param>
+    /// <returns>A api-valid string representation of <see cref="RankingType" />.</returns>
+    public static string ToApiString(this RankingType? rankingType)
+    {
+        return rankingType.HasValue ? ToApiString(rankingType.Value) : "";
+    }
 }

--- a/src/OsuSharp/Extensions/EnumExtensions.cs
+++ b/src/OsuSharp/Extensions/EnumExtensions.cs
@@ -157,4 +157,29 @@ internal static class EnumExtensions
     {
         return rankingType.HasValue ? ToApiString(rankingType.Value) : "";
     }
+
+    /// <summary>
+    /// Returns a string that fits osu! API requirements for <see cref="RankingVariant" />.
+    /// </summary>
+    /// <param name="rankingVariant">The type to get the string for.</param>
+    /// <returns>A api-valid string representation of <see cref="RankingVariant" />.</returns>
+    public static string ToApiString(this RankingVariant rankingVariant)
+    {
+        return rankingVariant switch
+        {
+            RankingVariant.Key4 => "4k",
+            RankingVariant.Key7 => "7k",
+            _ => ""
+        };
+    }
+
+    /// <summary>
+    /// Returns a string that fits osu! API requirements for <see cref="RankingVariant" />.
+    /// </summary>
+    /// <param name="rankingVariant">The type to get the string for.</param>
+    /// <returns>A api-valid string representation of <see cref="RankingVariant" />.</returns>
+    public static string ToApiString(this RankingVariant? rankingVariant)
+    {
+        return rankingVariant.HasValue ? ToApiString(rankingVariant.Value) : "";
+    }
 }

--- a/src/OsuSharp/OsuClient.cs
+++ b/src/OsuSharp/OsuClient.cs
@@ -1242,6 +1242,46 @@ public sealed class OsuClient : IOsuClient
         }, token).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Gets score rankings from the API.
+    /// </summary>
+    /// <param name="gameMode">The game mode to fetch rankings from.</param>
+    /// <param name="page">(Optional) The page to fetch rankings from. Defaults to the first page.</param>
+    /// <param name="filter">(Optional) Filter by results by all or by friends. Defaults to all.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>Returns an <see cref="IRankingScore"/> instance.</returns>
+    public async Task<IRankingScore> GetScoreRankingsAsync(
+        GameMode gameMode,
+        int? page = null,
+        RankingFilter? filter = null,
+        CancellationToken token = default)
+    {
+        ThrowIfDisposed();
+        await GetOrUpdateAccessTokenAsync(token).ConfigureAwait(false);
+
+        Uri.TryCreate(
+            string.Format(Endpoints.RankingsEndpoint, gameMode.ToApiString(), RankingType.Score.ToApiString()),
+            UriKind.Relative, out var uri);
+
+        IDictionary<string, string> parameters = new Dictionary<string, string>();
+
+        if (page.HasValue)
+            parameters["cursor[page]"] = page.Value.ToString();
+
+        if (filter.HasValue)
+            parameters["filter"] = filter.Value.ToApiString();
+
+        return await _handler.SendAsync<RankingScore, RankingScoreJsonModel>(new OsuApiRequest
+        {
+            Endpoint = Endpoints.RankingsEndpoint,
+            Method = HttpMethod.Get,
+            Route = uri!,
+            Token = _credentials,
+            Parameters = parameters,
+            Client = this
+        }, token).ConfigureAwait(false);
+    }
+
     private void ThrowIfDisposed()
     {
         if (_disposed)


### PR DESCRIPTION
Adds support for the [rankings](https://osu.ppy.sh/docs/index.html#ranking) endpoint.

**Example:**

Link: https://osu.ppy.sh/rankings/osu/charts?spotlight=276

```csharp
IRankingSpotlight spotlight = await _client.GetSpotlightRankingsAsync(GameMode.Osu, spotlightId: 276, token: stoppingToken);
IUserStatistics userStatistics = spotlight.Ranking[0];

_logger.LogInformation("Username: {Username}, Accuracy: {Accuracy:N2}%, Play Count: {PlayCount:N0}",
    userStatistics.User.Username, userStatistics.HitAccuracy, userStatistics.PlayCount);
```

**Expected Output:**

![image](https://user-images.githubusercontent.com/10572146/191951149-2d8b3735-800c-45d2-8836-0c217c3c3fc3.png)

**Actual Output:**
```
Username: Kingling, Accuracy: 98.93%, Play Count: 27
```